### PR TITLE
Fix usb_cdc_getc()

### DIFF
--- a/usb_cdc/usb_cdc.c
+++ b/usb_cdc/usb_cdc.c
@@ -340,7 +340,7 @@ usb_cdc_init (const usb_cdc_cfg_t *cfg)
 int
 usb_cdc_getc (usb_cdc_t usb_cdc)
 {
-    int ret = -1;
+    char ret = 0;
 
     if (! usb_cdc_read (usb_cdc, &ret, sizeof (ret)))
         return -1;


### PR DESCRIPTION
Only one byte is read in usb_cdc_read(), so passing an integer means the
upper three bytes are unchanged. Since the integer was initialised to
-1, this meant the overall returned value was negative, even for a valid
character.