### PR TITLE
Fix return value checking in usb_cdc_getc() and usb_cdc_putc().

### DIFF
--- a/usb_cdc/usb_cdc.c
+++ b/usb_cdc/usb_cdc.c
@@ -342,7 +342,7 @@ usb_cdc_getc (usb_cdc_t usb_cdc)
 {
     char ret = 0;
 
-    if (! usb_cdc_read (usb_cdc, &ret, sizeof (ret)))
+    if (usb_cdc_read (usb_cdc, &ret, sizeof (ret)) < 0)
         return -1;
 
     if (ret == '\r')
@@ -359,7 +359,7 @@ usb_cdc_putc (usb_cdc_t usb_cdc, char ch)
     if (ch == '\n')
         usb_cdc_putc (usb_cdc, '\r');    
 
-    if (! usb_cdc_write (usb_cdc, &ch, sizeof (ch)))
+    if (usb_cdc_write (usb_cdc, &ch, sizeof (ch)) < 0)
         return -1;
     return ch;
 }


### PR DESCRIPTION
usb_cdc_read() and usb_cdc_write() return -1 in the case of an error,
but usb_cdc_getc() and usb_cdc_putc() were treating the value as a
Boolean and so never noticed an error.

This meant, for example, that calling usb_cdc_puts() with a string
several times too long for the CDC ring buffer would tell you it had
successfully sent even though it hadn't....