### PR TITLE
Mark USB CDC device as not connected when USB connection is lost.

### DIFF
--- a/usb_cdc/usb_cdc.c
+++ b/usb_cdc/usb_cdc.c
@@ -380,7 +380,13 @@ bool
 usb_cdc_update (void)
 {
     /* This is needed to signal USB device.  */
-    return usb_poll ((&usb_cdc_dev)->usb);
+    bool ret = usb_poll ((&usb_cdc_dev)->usb);
+
+    /* USB disconnect == no terminal connected. */
+    if (!ret && usb_cdc_dev.connected)
+        usb_cdc_dev.connected = 0;
+
+    return ret;
 }
 
 


### PR DESCRIPTION
For example, if the cable is pulled out when a terminal is connected to the device, we won't get a SET_CONTROL_LINE_STATE packet and so the 'connected' field of the driver will remain true. If usb_poll() returns false, the device is not configured and so we can assume that there is no longer an active connection.