### PR TITLE
usb_cdc: store TX ring buffer on stack

### DIFF
--- a/panic/panic.c
+++ b/panic/panic.c
@@ -6,9 +6,10 @@ panic (pio_t led_error_pio, unsigned int error_code)
 {
     unsigned int i;
 
-    pio_config_set (led_error_pio, PIO_OUTPUT_LOW);
-#ifndef LED_ACTIVE
+#ifdef LED_ACTIVE
     pio_output_set (led_error_pio, LED_ACTIVE);
+#else
+    pio_config_set (led_error_pio, PIO_OUTPUT_LOW);
 #endif
 
     while (1)

--- a/tty/tty.c
+++ b/tty/tty.c
@@ -15,11 +15,8 @@
 #include "tty.h"
 #include "sys.h"
 #include "errno.h"
-#include <ctype.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <stdarg.h>
-#include <string.h>
 
 
 struct tty_struct

--- a/usb_cdc/usb_cdc.c
+++ b/usb_cdc/usb_cdc.c
@@ -2,7 +2,6 @@
 #include "usb_cdc.h"
 #include "usb_dsc.h"
 #include "usb.h"
-#include <stdlib.h>
 
 
 /* CDC communication device class.
@@ -20,10 +19,6 @@
 
 #ifndef USB_CURRENT_MA
 #define USB_CURRENT_MA 100
-#endif
-
-#ifndef USB_CDC_TX_RING_SIZE
-#define USB_CDC_TX_RING_SIZE 80
 #endif
 
 
@@ -343,11 +338,7 @@ usb_cdc_init (const usb_cdc_cfg_t *cfg)
     dev->writing = 0;
     dev->connected = 0;
 
-    buffer = malloc (USB_CDC_TX_RING_SIZE);
-    if (!buffer)
-        return 0;
-
-    ring_init (&dev->tx_ring, buffer, USB_CDC_TX_RING_SIZE);
+    ring_init (&dev->tx_ring, dev->tx_ring_buffer, USB_CDC_TX_RING_SIZE);
 
     dev->usb = usb_init (&usb_cdc_descriptors,
                          (void *)usb_cdc_request_handler);

--- a/usb_cdc/usb_cdc.h
+++ b/usb_cdc/usb_cdc.h
@@ -11,10 +11,16 @@ extern "C" {
 #include "ring.h"
     
 
+#ifndef USB_CDC_TX_RING_SIZE
+#define USB_CDC_TX_RING_SIZE 80
+#endif
+
+
 typedef struct usb_cdc_struct
 {
     usb_t usb;
     ring_t tx_ring;
+    uint8_t tx_ring_buffer[USB_CDC_TX_RING_SIZE];
     uint32_t read_timeout_us;
     uint32_t write_timeout_us;
     volatile bool writing;


### PR DESCRIPTION
Since there is only one USB CDC device and the buffer size is set at compile time